### PR TITLE
[rosserial_python] Print topic_name in addition to topic_id

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -473,7 +473,7 @@ class SerialClient:
 
                 # topic id (2 bytes)
                 topic_id_header = self.tryRead(2)
-                topic_id, = struct.unpack("<h", topic_id_header)
+                topic_id, topic_name, = struct.unpack("<h", topic_id_header)
 
                 try:
                     msg = self.tryRead(msg_length)
@@ -492,7 +492,7 @@ class SerialClient:
                     try:
                         self.callbacks[topic_id](msg)
                     except KeyError:
-                        rospy.logerr("Tried to publish before configured, topic id %d" % topic_id)
+                        rospy.logerr("Tried to publish before configured. Topic id: %d, name: %s" % topic_id, topic_name)
                     rospy.sleep(0.001)
                 else:
                     rospy.loginfo("wrong checksum for topic id and msg")

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -480,7 +480,7 @@ class SerialClient:
                 except IOError:
                     self.sendDiagnostics(diagnostic_msgs.msg.DiagnosticStatus.ERROR, "Packet Failed : Failed to read msg data")
                     rospy.loginfo("Packet Failed :  Failed to read msg data")
-                    rospy.loginfo("msg len is %d",len(msg))
+                    rospy.loginfo("msg len is %d. Topic id: %d, name: %s", len(msg), topic_id, topic_name)
                     raise
 
                 # checksum for topic id and msg

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -470,7 +470,7 @@ class SerialClient:
 
                 if msg_len_checksum % 256 != 255:
                     rospy.loginfo("wrong checksum for msg length, length %d" %(msg_length))
-                    rospy.loginfo("chk is %d", ord(msg_len_chk))
+                    rospy.logdebug("chk is %d", ord(msg_len_chk))
                     continue
 
                 # topic id (2 bytes)
@@ -481,12 +481,12 @@ class SerialClient:
                     topic_name = "system function"
                 elif topic_id < 0:
                     topic_name = "invalid topic_id"
-                    rospy.logwarn("Invalid (negative) topic_id!")
+                    rospy.logdebug("Invalid (negative) topic_id!")
                 else:
                     try:
                         topic_name = self.topics[topic_id]
                     except KeyError:
-                        rospy.logwarn("No topic_name for id %d yet!", topic_id)
+                        rospy.logdebug("No topic_name for id %d yet!", topic_id)
                         topic_name = "not configured yet"
 
                 try:

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -495,7 +495,7 @@ class SerialClient:
                         rospy.logerr("Tried to publish before configured. Topic id: %d, name: %s" % topic_id, topic_name)
                     rospy.sleep(0.001)
                 else:
-                    rospy.loginfo("wrong checksum for topic id and msg")
+                    rospy.loginfo("Wrong checksum for topic id and msg. Topic id: %d, name: %s" % topic_id, topic_name)
 
             except IOError:
                 # One of the read calls had an issue. Just to be safe, request that the client

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -506,7 +506,7 @@ class SerialClient:
                     try:
                         self.callbacks[topic_id](msg)
                     except KeyError:
-                        rospy.logerr("Tried to publish before configured. Topic id: %d, name: %s", topic_id, topic_name)
+                        rospy.logerr("Tried to publish before configured. Topic id: %d", topic_id)
                     rospy.sleep(0.001)
                 else:
                     rospy.loginfo("Wrong checksum for topic id and msg. Topic id: %d, name: %s", topic_id, topic_name)

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -498,8 +498,9 @@ class SerialClient:
                     rospy.loginfo("Wrong checksum for topic id and msg. Topic id: %d, name: %s", topic_id, topic_name)
 
             except IOError:
-                # One of the read calls had an issue. Just to be safe, request that the client
-                # reinitialize their topics.
+                # One of the read calls had an issue. Just to be safe,
+                # request that the client reinitialize their topics.
+                rospy.logwarn("Requesting reinitialization of client topics!")
                 self.requestTopics()
 
     def setPublishSize(self, bytes):

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -468,7 +468,7 @@ class SerialClient:
 
                 if msg_len_checksum % 256 != 255:
                     rospy.loginfo("wrong checksum for msg length, length %d" %(msg_length))
-                    rospy.loginfo("chk is %d" % ord(msg_len_chk))
+                    rospy.loginfo("chk is %d", ord(msg_len_chk))
                     continue
 
                 # topic id (2 bytes)
@@ -492,10 +492,10 @@ class SerialClient:
                     try:
                         self.callbacks[topic_id](msg)
                     except KeyError:
-                        rospy.logerr("Tried to publish before configured. Topic id: %d, name: %s" % topic_id, topic_name)
+                        rospy.logerr("Tried to publish before configured. Topic id: %d, name: %s", topic_id, topic_name)
                     rospy.sleep(0.001)
                 else:
-                    rospy.loginfo("Wrong checksum for topic id and msg. Topic id: %d, name: %s" % topic_id, topic_name)
+                    rospy.loginfo("Wrong checksum for topic id and msg. Topic id: %d, name: %s", topic_id, topic_name)
 
             except IOError:
                 # One of the read calls had an issue. Just to be safe, request that the client

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -477,8 +477,11 @@ class SerialClient:
                 topic_id_header = self.tryRead(2)
                 topic_id, = struct.unpack("<h", topic_id_header)
 
-                if topic_id < 100:
+                if topic_id >= 0 and topic_id < 100:
                     topic_name = "system function"
+                elif topic_id < 0:
+                    topic_name = "invalid topic_id"
+                    rospy.logwarn("Invalid (negative) topic_id!")
                 else:
                     try:
                         topic_name = self.topics[topic_id]

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -475,7 +475,16 @@ class SerialClient:
 
                 # topic id (2 bytes)
                 topic_id_header = self.tryRead(2)
-                topic_id, topic_name, = struct.unpack("<h", topic_id_header)
+                topic_id, = struct.unpack("<h", topic_id_header)
+
+                if topic_id < 100:
+                    topic_name = "system function"
+                else:
+                    try:
+                        topic_name = self.topics[topic_id]
+                    except KeyError:
+                        rospy.logwarn("No topic_name for id %d yet!", topic_id)
+                        topic_name = "not configured yet"
 
                 try:
                     msg = self.tryRead(msg_length)


### PR DESCRIPTION
Introduces a mapping between `topic_id` and `topic_name` to allow printing of `topic_name` in logging statements for easier debugging.

Reference: http://wiki.ros.org/rosserial/Overview/Protocol

@nckswt Please take a quick look too as it will help with what you'll start seeing on `rosout`